### PR TITLE
feat: add endpoint delay

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,8 @@ export const HTTP_STATUS = {
 } as const;
 
 export const DEFAULT_HTTP_STATUS = HTTP_STATUS.OK;
+
+export const DELAY = {
+  MIN: 0,
+  MAX: 10_000,
+} as const;

--- a/src/services/MockServerManager.ts
+++ b/src/services/MockServerManager.ts
@@ -11,6 +11,7 @@ import {
   MockServerConfig,
   MockServerInstance,
 } from '../types/index.js';
+import { delay } from '../utils/delay.js';
 
 export class MockServerManager {
   private servers: Map<number, MockServer> = new Map();
@@ -219,6 +220,10 @@ export class MockServerManager {
 
     app[method](endpoint.path, async (_req: Request, res: Response) => {
       try {
+        if (endpoint.delay && endpoint.delay > 0) {
+          await delay(endpoint.delay);
+        }
+
         if (endpoint.errorResponse?.enabled) {
           return res.status(endpoint.errorResponse.status).json({
             error: endpoint.errorResponse.message,

--- a/src/tools/listEndpoints.ts
+++ b/src/tools/listEndpoints.ts
@@ -39,7 +39,8 @@ export async function handleListEndpoints(
           const errorInfo = ep.errorResponse
             ? ` [Error: ${ep.errorResponse.enabled ? 'ON' : 'OFF'}]`
             : '';
-          return `  ${ep.method} ${ep.path} → ${ep.response.status}${errorInfo}`;
+          const delayInfo = ep.delay ? ` [Delay: ${ep.delay}ms]` : '';
+          return `  ${ep.method} ${ep.path} → ${ep.response.status}${errorInfo}${delayInfo}`;
         })
         .join('\n');
 
@@ -67,7 +68,8 @@ export async function handleListEndpoints(
                     const errorInfo = ep.errorResponse
                       ? ` [Error: ${ep.errorResponse.enabled ? 'ON' : 'OFF'}]`
                       : '';
-                    return `    ${ep.method} ${ep.path} → ${ep.response.status}${errorInfo}`;
+                    const delayInfo = ep.delay ? ` [Delay: ${ep.delay}ms]` : '';
+                    return `    ${ep.method} ${ep.path} → ${ep.response.status}${errorInfo}${delayInfo}`;
                   })
                   .join('\n')
               : '    No endpoints configured';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export interface MockEndpoint {
     headers?: Record<string, string>;
     body: unknown;
   };
+  delay?: number;
   errorResponse?: {
     enabled: boolean;
     status: number;

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -1,0 +1,3 @@
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/toolHandlers.test.ts
+++ b/tests/toolHandlers.test.ts
@@ -25,11 +25,17 @@ describe('Tool Handlers', () => {
 
       vi.spyOn(mockServerManager, 'startServer').mockResolvedValue(mockServer);
 
-      const result = await handleStartMockServer(mockServerManager, { port: 9878 });
+      const result = await handleStartMockServer(mockServerManager, {
+        port: 9878,
+      });
 
-      expect(result.content[0].text).toContain('Mock server started successfully');
+      expect(result.content[0].text).toContain(
+        'Mock server started successfully'
+      );
       expect(result.content[0].text).toContain('port 9878');
-      expect(mockServerManager.startServer).toHaveBeenCalledWith({ port: 9878 });
+      expect(mockServerManager.startServer).toHaveBeenCalledWith({
+        port: 9878,
+      });
     });
 
     it('should handle server startup failure', async () => {
@@ -37,7 +43,9 @@ describe('Tool Handlers', () => {
         new Error('Port already in use')
       );
 
-      const result = await handleStartMockServer(mockServerManager, { port: 9878 });
+      const result = await handleStartMockServer(mockServerManager, {
+        port: 9878,
+      });
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('Failed to start mock server');
@@ -45,10 +53,14 @@ describe('Tool Handlers', () => {
     });
 
     it('should validate port range', async () => {
-      const result = await handleStartMockServer(mockServerManager, { port: 500 });
+      const result = await handleStartMockServer(mockServerManager, {
+        port: 500,
+      });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Port must be between 1024 and 65535');
+      expect(result.content[0].text).toContain(
+        'Port must be between 1024 and 65535'
+      );
     });
   });
 
@@ -56,25 +68,37 @@ describe('Tool Handlers', () => {
     it('should stop server successfully', async () => {
       vi.spyOn(mockServerManager, 'stopServer').mockResolvedValue(true);
 
-      const result = await handleStopMockServer(mockServerManager, { port: 9878 });
+      const result = await handleStopMockServer(mockServerManager, {
+        port: 9878,
+      });
 
-      expect(result.content[0].text).toContain('Mock server on port 9878 stopped successfully');
+      expect(result.content[0].text).toContain(
+        'Mock server on port 9878 stopped successfully'
+      );
       expect(mockServerManager.stopServer).toHaveBeenCalledWith(9878);
     });
 
     it('should handle when no server is running', async () => {
       vi.spyOn(mockServerManager, 'stopServer').mockResolvedValue(false);
 
-      const result = await handleStopMockServer(mockServerManager, { port: 9878 });
+      const result = await handleStopMockServer(mockServerManager, {
+        port: 9878,
+      });
 
-      expect(result.content[0].text).toContain('No running server found on port 9878');
+      expect(result.content[0].text).toContain(
+        'No running server found on port 9878'
+      );
     });
 
     it('should validate port range', async () => {
-      const result = await handleStopMockServer(mockServerManager, { port: 70000 });
+      const result = await handleStopMockServer(mockServerManager, {
+        port: 70000,
+      });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Port must be between 1024 and 65535');
+      expect(result.content[0].text).toContain(
+        'Port must be between 1024 and 65535'
+      );
     });
   });
 
@@ -113,7 +137,9 @@ describe('Tool Handlers', () => {
       const result = await handleAddEndpoint(mockServerManager, args);
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('No running server found on port 9878');
+      expect(result.content[0].text).toContain(
+        'No running server found on port 9878'
+      );
     });
 
     it('should use default status code when not provided', async () => {
@@ -130,9 +156,54 @@ describe('Tool Handlers', () => {
 
       await handleAddEndpoint(mockServerManager, args);
 
-      const addEndpointCall = vi.mocked(mockServerManager.addEndpoint).mock.calls[0];
+      const addEndpointCall = vi.mocked(mockServerManager.addEndpoint).mock
+        .calls[0];
       const endpoint = addEndpointCall[1];
       expect(endpoint.response.status).toBe(200);
+    });
+
+    it('should add endpoint with delay', async () => {
+      vi.spyOn(mockServerManager, 'addEndpoint').mockResolvedValue(true);
+
+      const args = {
+        port: 9878,
+        method: 'GET',
+        path: '/test',
+        response: {
+          body: { message: 'test' },
+        },
+        delay: 1000,
+      };
+
+      const result = await handleAddEndpoint(mockServerManager, args);
+
+      expect(result.content[0].text).toContain('Endpoint added successfully');
+      expect(result.content[0].text).toContain('Delay: 1000ms');
+
+      const addEndpointCall = vi.mocked(mockServerManager.addEndpoint).mock
+        .calls[0];
+      const endpoint = addEndpointCall[1];
+      expect(endpoint.delay).toBe(1000);
+    });
+
+    it('should add endpoint without delay when not provided', async () => {
+      vi.spyOn(mockServerManager, 'addEndpoint').mockResolvedValue(true);
+
+      const args = {
+        port: 9878,
+        method: 'GET',
+        path: '/test',
+        response: {
+          body: { message: 'test' },
+        },
+      };
+
+      await handleAddEndpoint(mockServerManager, args);
+
+      const addEndpointCall = vi.mocked(mockServerManager.addEndpoint).mock
+        .calls[0];
+      const endpoint = addEndpointCall[1];
+      expect(endpoint.delay).toBeUndefined();
     });
   });
 
@@ -150,7 +221,11 @@ describe('Tool Handlers', () => {
 
       expect(result.content[0].text).toContain('Endpoint removed successfully');
       expect(result.content[0].text).toContain('GET /test');
-      expect(mockServerManager.removeEndpoint).toHaveBeenCalledWith(9878, 'GET', '/test');
+      expect(mockServerManager.removeEndpoint).toHaveBeenCalledWith(
+        9878,
+        'GET',
+        '/test'
+      );
     });
 
     it('should handle when endpoint not found', async () => {
@@ -165,7 +240,9 @@ describe('Tool Handlers', () => {
       const result = await handleRemoveEndpoint(mockServerManager, args);
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Server not found on port 9878 or endpoint doesn\'t exist');
+      expect(result.content[0].text).toContain(
+        "Server not found on port 9878 or endpoint doesn't exist"
+      );
     });
   });
 
@@ -191,9 +268,13 @@ describe('Tool Handlers', () => {
         instance: undefined,
       };
 
-      vi.spyOn(mockServerManager, 'getServerStatus').mockReturnValue(mockServer);
+      vi.spyOn(mockServerManager, 'getServerStatus').mockReturnValue(
+        mockServer
+      );
 
-      const result = await handleListEndpoints(mockServerManager, { port: 9878 });
+      const result = await handleListEndpoints(mockServerManager, {
+        port: 9878,
+      });
 
       expect(result.content[0].text).toContain('Endpoints (2)');
       expect(result.content[0].text).toContain('GET /test');
@@ -208,9 +289,13 @@ describe('Tool Handlers', () => {
         instance: undefined,
       };
 
-      vi.spyOn(mockServerManager, 'getServerStatus').mockReturnValue(mockServer);
+      vi.spyOn(mockServerManager, 'getServerStatus').mockReturnValue(
+        mockServer
+      );
 
-      const result = await handleListEndpoints(mockServerManager, { port: 9878 });
+      const result = await handleListEndpoints(mockServerManager, {
+        port: 9878,
+      });
 
       expect(result.content[0].text).toContain('No endpoints configured');
     });
@@ -218,9 +303,48 @@ describe('Tool Handlers', () => {
     it('should handle when server is not running', async () => {
       vi.spyOn(mockServerManager, 'getServerStatus').mockReturnValue(null);
 
-      const result = await handleListEndpoints(mockServerManager, { port: 9878 });
+      const result = await handleListEndpoints(mockServerManager, {
+        port: 9878,
+      });
 
       expect(result.content[0].text).toContain('No server found on port 9878');
+    });
+
+    it('should display delay information when endpoints have delays', async () => {
+      const mockServer = {
+        port: 9878,
+        endpoints: [
+          {
+            id: '1',
+            method: 'GET' as const,
+            path: '/fast',
+            response: { status: 200, body: { message: 'fast' } },
+          },
+          {
+            id: '2',
+            method: 'POST' as const,
+            path: '/slow',
+            response: { status: 201, body: { id: 1 } },
+            delay: 2000,
+          },
+        ],
+        isRunning: true,
+        instance: undefined,
+      };
+
+      vi.spyOn(mockServerManager, 'getServerStatus').mockReturnValue(
+        mockServer
+      );
+
+      const result = await handleListEndpoints(mockServerManager, {
+        port: 9878,
+      });
+
+      expect(result.content[0].text).toContain('GET /fast → 200');
+      expect(result.content[0].text).toContain(
+        'POST /slow → 201 [Delay: 2000ms]'
+      );
+      expect(result.content[0].text).not.toContain('GET /fast → 200 [Delay:');
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a response delay (in milliseconds) when creating mock endpoints.
  - Endpoint listings now display delay information if configured.

- **Bug Fixes**
  - Improved accuracy and display of delay information for endpoints.

- **Tests**
  - Expanded test coverage to verify endpoint delay functionality and ensure correct delay handling in responses.
  - Improved test formatting for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->